### PR TITLE
Add entrypoint to the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,4 @@ RUN go mod download -x
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -o qubership-open-telemetry-collector .
 
 FROM alpine:3.21.0
-COPY --from=builder --chown=10001:10001 /workspace/qubership-open-telemetry-collector /otec
+COPY --from=builder --chown=10001:10001 --chmod=755 /workspace/qubership-open-telemetry-collector /otec

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,5 @@ RUN go mod download -x
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -o qubership-open-telemetry-collector .
 
 FROM alpine:3.21.0
-COPY --from=builder --chown=10001:10001 --chmod=755 /workspace/qubership-open-telemetry-collector /otec
+COPY --from=builder --chown=10001:0 /workspace/qubership-open-telemetry-collector /otec
+ENTRYPOINT ["/otec"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,4 @@ RUN go mod download -x
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -o qubership-open-telemetry-collector .
 
 FROM alpine:3.21.0
-COPY --from=builder --chown=10001:0 /workspace/qubership-open-telemetry-collector /otec
+COPY --from=builder --chown=10001:10001 /workspace/qubership-open-telemetry-collector /otec


### PR DESCRIPTION
During opentelemetry-operator deployment was tested with qubership-opentelemetry-collector, it was found that the collector pod could not be started. It is necessary to specify ENTRYPOINT in the Dockerfile. After this, operator was able to run the collector pod.