### PR TITLE
chore: update scout-repo-scan.yaml

### DIFF
--- a/.github/workflows/scout-repo-scan.yaml
+++ b/.github/workflows/scout-repo-scan.yaml
@@ -29,6 +29,7 @@ permissions:
   contents: read
 jobs:
   scout_repo_scan:
+    if: github.actor != 'dependabot[bot]'
     permissions:
       contents: read
       security-events: write


### PR DESCRIPTION
Added condition `if: github.actor != 'dependabot[bot]'` to prevent execution on PRs made by dependabot