### PR TITLE
fix(ci): update Grafana dashboard CRD URL

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -127,7 +127,7 @@ jobs:
 
       - name: Install required CRDs
         run: |
-            kubectl apply -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/heads/main/charts/qubership-monitoring-operator/charts/grafana-operator/crds/integreatly.org_grafanadashboards.yaml
+            kubectl apply -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/heads/main/charts/qubership-monitoring-operator/charts/grafana-operator/crds/grafana.integreatly.org_grafanadashboards.yaml
             kubectl apply -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/heads/main/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_prometheusrules.yaml
             kubectl apply -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/heads/main/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_servicemonitors.yaml
             kubectl apply -f https://raw.githubusercontent.com/Netcracker/qubership-monitoring-operator/refs/heads/main/charts/qubership-monitoring-operator/charts/victoriametrics-operator/crds/monitoring.coreos.com_podmonitors.yaml


### PR DESCRIPTION
## Why

All pull request integration tests fail while installing required CRDs because qubership-monitoring-operator renamed the Grafana dashboard CRD file for the Grafana Operator v5 API.

## What

- Update the Grafana dashboard CRD URL to grafana.integreatly.org_grafanadashboards.yaml.
- Keep the remaining CRD installation URLs unchanged.

## How to verify

- Run pre-commit run check-yaml --files .github/workflows/integration_test.yaml.
- Run pre-commit run yamllint --files .github/workflows/integration_test.yaml.
- Run actionlint .github/workflows/integration_test.yaml.
- Confirm that the updated CRD URL returns HTTP 200.
